### PR TITLE
fix: correct GitHub repository URL

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
           The visual cloud native management platform. Design, deploy, and manage your Kubernetes infrastructure collaboratively and easily.
         </p>
         <div class="social-links">
-          <a href="https://github.com/meshery/kanvas" target="_blank" rel="noreferrer"><i class="fab fa-github"></i></a>
+          <a href="https://github.com/meshery-extensions/kanvas-site" target="_blank" rel="noreferrer"><i class="fab fa-github"></i></a>
           <a href="https://slack.layer5.io" target="_blank" rel="noreferrer"><i class="fab fa-slack"></i></a>
           <a href="https://twitter.com/layer5" target="_blank" rel="noreferrer"><i class="fab fa-twitter"></i></a>
           <a href="https://youtube.com/layer5" target="_blank" rel="noreferrer"><i class="fab fa-youtube"></i></a>


### PR DESCRIPTION
**Notes for Reviewers**

The GitHub url currently point to https://github.com/meshery/kanvas, and that address does not exist.
I have updated the url to https://github.com/meshery-extensions/kanvas-site

- This PR fixes #85


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
