### PR TITLE
Fix: "Browser" section - don't stretch display

### DIFF
--- a/assets/scss/_browser.scss
+++ b/assets/scss/_browser.scss
@@ -104,7 +104,6 @@
   align-items: center;
   justify-content: center;
   gap: 34px;
-  transform: scale(unquote("min(1, calc(100cqi / 980))"));
   transform-origin: center center;
 }
 

--- a/layouts/partials/section/browser.html
+++ b/layouts/partials/section/browser.html
@@ -36,4 +36,19 @@
     <div class="browser-stand"></div>
     <div class="browser-shadow"></div>
   </div>
+  <script>
+    (function() {
+      const mockup = document.querySelector('.browser-mockup');
+      const inner = document.querySelector('.browser-body-inner');
+      if (mockup && inner) {
+        new ResizeObserver(entries => {
+          for (let entry of entries) {
+             const width = entry.contentRect.width;
+             const scale = Math.min(1, Math.max(0.2, width / 980));
+             inner.style.transform = `scale(${scale})`;
+          }
+        }).observe(mockup);
+      }
+    })();
+  </script>
 </section>


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #153 , #152 

<img width="581" height="864" alt="image" src="https://github.com/user-attachments/assets/c22f1d4a-04db-4585-9816-3c212ae2a3e6" />

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
