### PR TITLE
fix(hero): add responsive padding/margin and reduce font-size on mobile

### DIFF
--- a/assets/scss/_hero.scss
+++ b/assets/scss/_hero.scss
@@ -152,3 +152,37 @@
     }
   }
 }
+
+@media (max-width: 768px) {
+  .hero-section {
+    padding: $spacer * 2 $spacer * 1.5;
+
+    .hero-stats {
+      gap: 2rem;
+      padding-top: 2rem;
+
+      .stat-item {
+        strong {
+          font-size: 1.2rem;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-section {
+    padding: $spacer * 1.5 $spacer;
+
+    .hero-stats {
+      gap: 1.5rem;
+      padding-top: 1.5rem;
+
+      .stat-item {
+        strong {
+          font-size: 1.1rem;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Add @media (max-width: 768px): reduce .hero-stats gap to 2rem, padding-top to 2rem, and counter font-size to 1.2rem
- Add @media (max-width: 480px): further reduce padding, gap to 1.5rem, and counter font-size to 1.1rem so stat suffix stays inline

Fixes #113
 
**screenshot:-**
<img width="1626" height="1050" alt="image" src="https://github.com/user-attachments/assets/ae076fdf-2377-4a09-bc64-ff5561bd3634" />



**Notes for Reviewers**

- This PR fixes #113

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
