### PR TITLE
Fix OpenGraph and Twitter image paths

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Kanvas"
-description: "Collaboration for cloud native infrastructure"
+description: "Kanvas empowers engineers to design, deploy, and manage cloud native infrastructure collaboratively. As a Google Workspace-like experience for Kubernetes, Kanvas transforms infrastructure management from YAML to visual intuition."
 ---
 
 # Kanvas

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "http://www.kanvas.new"
+baseURL = "https://meshery-extensions.github.io/kanvas-site/"
 title = "Kanvas"
 relativeURLs = true
 canonifyurls = false
@@ -33,4 +33,4 @@ enableMissingTranslationPlaceholders = true
   logo_dark = "images/kanvas-logo-dark.svg"
   description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
 
-  canonicalBaseURL = "https://www.kanvas.new"
+  canonicalBaseURL = "https://meshery-extensions.github.io/kanvas-site/"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://meshery-extensions.github.io/kanvas-site/"
+baseURL = "http://www.kanvas.new"
 title = "Kanvas"
 relativeURLs = true
 canonifyurls = false
@@ -33,4 +33,4 @@ enableMissingTranslationPlaceholders = true
   logo_dark = "images/kanvas-logo-dark.svg"
   description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
 
-  canonicalBaseURL = "https://meshery-extensions.github.io/kanvas-site/"
+  canonicalBaseURL = "http://www.kanvas.new"

--- a/hugo.toml
+++ b/hugo.toml
@@ -31,6 +31,6 @@ enableMissingTranslationPlaceholders = true
   dark-mode = true
   logo_light = "images/kanvas-logo-light.svg"
   logo_dark = "images/kanvas-logo-dark.svg"
-  description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
+  description = "Infrastructure as Design for collaborative Cloud and Kubernetes management"
 
   canonicalBaseURL = "http://www.kanvas.new"

--- a/hugo.toml
+++ b/hugo.toml
@@ -30,5 +30,5 @@ enableMissingTranslationPlaceholders = true
   dark-mode = true
   logo_light = "images/kanvas-logo-light.svg"
   logo_dark = "images/kanvas-logo-dark.svg"
-  description = "Kanvas empowers engineers to design, deploy, and manage cloud native infrastructure collaboratively. As a Google Workspace-like experience for Kubernetes, Kanvas transforms infrastructure management from YAML to visual intuition."
+  description = "description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
   canonicalBaseURL = "https://www.kanvas.new"

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,6 +7,7 @@ canonifyurls = false
 contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
+# Useful when translating.
 enableMissingTranslationPlaceholders = true
 
 [menu]
@@ -30,5 +31,6 @@ enableMissingTranslationPlaceholders = true
   dark-mode = true
   logo_light = "images/kanvas-logo-light.svg"
   logo_dark = "images/kanvas-logo-dark.svg"
-  description = "description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
+  description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
+
   canonicalBaseURL = "https://www.kanvas.new"

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,6 @@ canonifyurls = false
 contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
-# Useful when translating.
 enableMissingTranslationPlaceholders = true
 
 [menu]
@@ -31,6 +30,5 @@ enableMissingTranslationPlaceholders = true
   dark-mode = true
   logo_light = "images/kanvas-logo-light.svg"
   logo_dark = "images/kanvas-logo-dark.svg"
-  description = "Infrastructure as Design for collaborative Cloud and Kubernetes management"
-
-  canonicalBaseURL = "http://www.kanvas.new"
+  description = "Kanvas empowers engineers to design, deploy, and manage cloud native infrastructure collaboratively. As a Google Workspace-like experience for Kubernetes, Kanvas transforms infrastructure management from YAML to visual intuition."
+  canonicalBaseURL = "https://www.kanvas.new"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,13 +16,13 @@
   <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:image" content="{{ printf "%s/images/screenshots/demo-thumbnail.webp" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+  <meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   <meta name="twitter:card" content="summary_large_image">
 
   <meta name="twitter:site" content="@mesheryio">
   <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
   <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-  <meta name="twitter:image" content="{{ printf "%s/images/screenshots/demo-thumbnail.webp" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+  <meta name="twitter:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   {{- with site.Params.canonicalBaseURL }}
   <link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">
   {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,13 +16,13 @@
   <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:image" content="{{ printf "%s/images/brand/kanvas/horizontal/kanvas-horizontal-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+  <meta property="og:image" content="{{ printf "%s/images/screenshots/demo-thumbnail.webp" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   <meta name="twitter:card" content="summary_large_image">
 
   <meta name="twitter:site" content="@mesheryio">
   <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
   <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-  <meta name="twitter:image" content="{{ printf "%s/images/brand/kanvas/horizontal/kanvas-horizontal-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+  <meta name="twitter:image" content="{{ printf "%s/images/screenshots/demo-thumbnail.webp" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   {{- with site.Params.canonicalBaseURL }}
   <link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">
   {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}" />
   <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ .Permalink }}" />
+  <meta property="og:url" content="https://kanvas.new{{ .RelPermalink }}" />
   <meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   <meta name="twitter:card" content="summary_large_image">
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}" />
   <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://kanvas.new{{ .RelPermalink }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
   <meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
   <meta name="twitter:card" content="summary_large_image">
 


### PR DESCRIPTION
This PR fixes incorrect OpenGraph and Twitter Card image paths in the Kanvas site.

Changes included:
- Updated `og:image` and `twitter:image` to use the stacked Kanvas logo
- Corrected the base URL and canonical URL to use http://www.kanvas.new
- Updated hugo.toml to ensure OG and Twitter tags resolve correctly
- Cleaned up duplicate meta tags in layouts/partials/head.html
- Ensured all social preview images load from the correct directory

Fixes #177.
