### PR TITLE
Fix: animations not shown when user disable animations from OS settings

### DIFF
--- a/assets/scss/_feedback.scss
+++ b/assets/scss/_feedback.scss
@@ -282,10 +282,3 @@
     }
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .feedback-section .feedback-card {
-    transition: none;
-    &:hover { transform: none; }
-  }
-}

--- a/assets/scss/_hero-glass.scss
+++ b/assets/scss/_hero-glass.scss
@@ -871,13 +871,3 @@ main {
     font-size: 0.85rem;
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}

--- a/assets/scss/_scroll-cube.scss
+++ b/assets/scss/_scroll-cube.scss
@@ -221,20 +221,3 @@
     bottom: -20px;
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .scroll-piece-anchor {
-    display: none;
-  }
-  .reunited-logo-inner {
-    animation: none;
-    transform: rotateY(-10deg) rotateX(4deg);
-  }
-  .reunited-float {
-    animation: none;
-  }
-  .reunited-glow {
-    animation: none;
-    opacity: 0.7;
-  }
-}

--- a/assets/scss/_section-transitions.scss
+++ b/assets/scss/_section-transitions.scss
@@ -127,26 +127,3 @@
     scroll-behavior: smooth;
   }
 }
-
-@media (prefers-reduced-motion: reduce) {
-  .section-reveal {
-    opacity: 1;
-    transform: none;
-    transition: none;
-  }
-
-  .section-reveal-children > * {
-    opacity: 1;
-    transform: none;
-    transition: none;
-  }
-
-  .section-divider {
-    opacity: 1;
-    transition: none;
-  }
-
-  .scroll-ambient {
-    display: none;
-  }
-}

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -357,7 +357,6 @@ const initScrollPieces = () => {
 };
 
 const initScrollAnimations = () => {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     // ── Background Ambient Overlay ──
     const ambient = document.createElement('div');


### PR DESCRIPTION
**Notes for Reviewers**
Animations got disabled when user disabled animations from OS settings.
<img width="1317" height="824" alt="image" src="https://github.com/user-attachments/assets/770586a8-0963-42b3-87ff-3d19ae4a91e6" />


After:
<img width="1915" height="947" alt="image" src="https://github.com/user-attachments/assets/9598a056-bf96-4c51-8097-203ca8ea9089" />


- This PR fixes #185

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
