### PR TITLE
fix: correct branding from 'kanvas.new' to 'Kanvas' and fix X/Twitter social preview 

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "http://www.kanvas.new"
+baseURL = "https://kanvas.new"        
 title = "Kanvas"
 relativeURLs = true
 canonifyurls = false
@@ -31,6 +31,6 @@ enableMissingTranslationPlaceholders = true
   dark-mode = true
   logo_light = "images/kanvas-logo-light.svg"
   logo_dark = "images/kanvas-logo-dark.svg"
-  description = "Infrastructure as Design for collaborative Cloud and Kubernetesmanagement"
+  description = "Infrastructure as Design for collaborative Cloud and Kubernetes management"
 
-  canonicalBaseURL = "https://www.kanvas.new"
+  canonicalBaseURL = "https://kanvas.new"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://kanvas.new"        
+baseURL = "/"        
 title = "Kanvas"
 relativeURLs = true
 canonifyurls = false
@@ -33,4 +33,4 @@ enableMissingTranslationPlaceholders = true
   logo_dark = "images/kanvas-logo-dark.svg"
   description = "Infrastructure as Design for collaborative Cloud and Kubernetes management"
 
-  canonicalBaseURL = "https://kanvas.new"
+  canonicalBaseURL = ""

--- a/hugo.toml
+++ b/hugo.toml
@@ -33,4 +33,4 @@ enableMissingTranslationPlaceholders = true
   logo_dark = "images/kanvas-logo-dark.svg"
   description = "Infrastructure as Design for collaborative Cloud and Kubernetes management"
 
-  canonicalBaseURL = ""
+  canonicalBaseURL = "https://www.kanvas.new"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,12 +20,12 @@
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:image" content="{{ .Site.BaseURL }}brand/kanvas/stacked/kanvas-stacked-color.png" />
+<meta property="og:image" content="https://www.kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png" />
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-<meta name="twitter:image" content="{{ .Site.BaseURL }}brand/kanvas/stacked/kanvas-stacked-color.png">
+<meta name="twitter:image" content="https://www.kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png">
 <meta name="twitter:url" content="{{ .Permalink }}">
 
 {{- with site.Params.canonicalBaseURL }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,36 +1,46 @@
 <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-  <link rel="manifest" href="/favicons/site.webmanifest">
-  <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg">
-  <link rel="shortcut icon" href="/favicons/favicon.ico">
-  <meta name="msapplication-TileColor" content="#da532c">
-  <meta name="msapplication-config" content="/favicons/browserconfig.xml">
-  <meta name="theme-color" content="#ffffff">
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
-  
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-  <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}" />
-  <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="{{ .Permalink }}" />
-  <meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
-  <meta name="twitter:card" content="summary_large_image">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <meta name="twitter:site" content="@mesheryio">
-  <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
-  <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-  <meta name="twitter:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
-  {{- with site.Params.canonicalBaseURL }}
-  <link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">
-  {{- end }}
-  {{- if eq (getenv "HUGO_PREVIEW") "true" }}
-  <meta name="robots" content="noindex, nofollow">
-  {{- end }}
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  {{ partial "head-css.html" . }}
+
+<link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
+<link rel="manifest" href="/favicons/site.webmanifest">
+<link rel="mask-icon" href="/favicons/safari-pinned-tab.svg">
+<link rel="shortcut icon" href="/favicons/favicon.ico">
+
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="msapplication-config" content="/favicons/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">
+
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+
+<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+
+<meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
+<meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+<meta name="twitter:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
+
+
+{{- with site.Params.canonicalBaseURL }}
+<link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">
+{{- end }}
+
+{{- if eq (getenv "HUGO_PREVIEW") "true" }}
+<meta name="robots" content="noindex, nofollow">
+{{- end }}
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+{{ partial "head-css.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,7 +33,7 @@
 {{- end }}
 
 {{- if eq (getenv "HUGO_PREVIEW") "true" }}
-<meta name="robots" content="noindex, nofollow">
+<meta name="robots" content="noindex">
 {{- end }}
 
 <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-
 <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
@@ -21,14 +20,12 @@
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
-
+<meta property="og:image" content="https://kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png" />
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-<meta name="twitter:image" content="{{ printf "%s/brand/kanvas/stacked/kanvas-stacked-color.png" (site.Params.canonicalBaseURL | strings.TrimRight "/") }}" />
-
+<meta name="twitter:image" content="https://kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png" />
 
 {{- with site.Params.canonicalBaseURL }}
 <link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,12 +20,13 @@
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:image" content="https://kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png" />
+<meta property="og:image" content="{{ .Site.BaseURL }}brand/kanvas/stacked/kanvas-stacked-color.png" />
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}">
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
-<meta name="twitter:image" content="https://kanvas.new/brand/kanvas/stacked/kanvas-stacked-color.png" />
+<meta name="twitter:image" content="{{ .Site.BaseURL }}brand/kanvas/stacked/kanvas-stacked-color.png">
+<meta name="twitter:url" content="{{ .Permalink }}">
 
 {{- with site.Params.canonicalBaseURL }}
 <link rel="canonical" href="{{ . | strings.TrimRight "/" }}{{ $.RelPermalink }}">


### PR DESCRIPTION
## What is the problem?

The site was displaying "kanvas.new" instead of the correct product name "Kanvas" in browser tabs and search results. Additionally, sharing the site link on X (Twitter) was showing a half image with no description in the preview.

Fixes #195

---

## What is the fix?

Updated the site configuration and meta tags to display correct branding:

Fixed baseURL, canonicalBaseURL, and title in hugo.toml
Added proper Open Graph meta tags — og:title, og:description, og:image
Added proper Twitter Card meta tags — twitter:card, twitter:title, twitter:description, twitter:image

---

## Files Changed

hugo.toml
layouts/partials/head.html

---

## Screenshots

After Fix — Browser tab now correctly shows "Kanvas"
<img width="1771" height="980" alt="image" src="https://github.com/user-attachments/assets/74f2dbce-8670-40ca-8b14-d1f1a10d2b4f" />


---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.