### PR TITLE
fix(ci): drop GH_ACCESS_TOKEN from public-repo checkout

### DIFF
--- a/.github/workflows/build-and-release-meshery-extensions.yml
+++ b/.github/workflows/build-and-release-meshery-extensions.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           repository: layer5labs/meshery-extensions
           path: meshery-extensions
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Disable Source Map Warnings
         run: |
           echo 'DISABLE_SOURCEMAP_WARNINGS=true' >> $GITHUB_ENV


### PR DESCRIPTION
## Summary
Fixes the failure in [run 24521408320](https://github.com/meshery-extensions/kanvas-site/actions/runs/24521408320):
```
Retrieving the default branch name
Bad credentials - https://docs.github.com/rest
```

`actions/checkout@v6` hit that error when resolving the default branch of `Remote/meshery-extensions` because the `GH_ACCESS_TOKEN` secret in this repo is rejected by the GitHub REST API (likely stale/expired).

`Remote/meshery-extensions` is public, so the initial checkout does not need a PAT. Removing the `token:` override lets `actions/checkout` fall back to the default `GITHUB_TOKEN`, which is always valid for REST API calls against public resources and for cloning any public repo regardless of the running repo's scope.

## Follow-up (not in this PR)
`GH_ACCESS_TOKEN` is still used for:
- `meshery/meshery` checkout (public, same workaround would apply if that token is bad)
- `Get Meshery Extensions Release draft` curl
- `Build meshery-extension` docker `TOKEN` build-arg
- Both `ncipollo/release-action` release steps (write access required — these genuinely need a working PAT)

If `GH_ACCESS_TOKEN` is truly expired, the later release steps will still fail and the secret will need to be rotated at the org level.

## Test plan
- [ ] Re-run "Build and Publish Meshery Extensions" via workflow_dispatch on master after merge.
- [ ] Verify the `Checkout Remote/meshery-extensions` step completes successfully.
- [ ] Watch subsequent steps — if the release steps fail with `401` / `Bad credentials`, the PAT needs rotation (out of scope for this PR).