### PR TITLE
fix(ci): use RELEASE_NOTES_PAT for cross-org access

### DIFF
--- a/.github/workflows/build-and-release-meshery-extensions.yml
+++ b/.github/workflows/build-and-release-meshery-extensions.yml
@@ -27,6 +27,7 @@ jobs:
           repository: layer5labs/meshery-extensions
           path: meshery-extensions
           token: ${{ secrets.RELEASE_NOTES_PAT }}
+          persist-credentials: false
       - name: Disable Source Map Warnings
         run: |
           echo 'DISABLE_SOURCEMAP_WARNINGS=true' >> $GITHUB_ENV

--- a/.github/workflows/build-and-release-meshery-extensions.yml
+++ b/.github/workflows/build-and-release-meshery-extensions.yml
@@ -110,13 +110,16 @@ jobs:
       - name: Build meshery-extension at version ${{ env.MESHERY_EXTENSIONS_PATH }}
         if: ${{ !failure() }}
         working-directory: ${{ env.MESHERY_EXTENSIONS_PATH }}
+        env:
+          DOCKER_BUILDKIT: "1"
+          RELEASE_NOTES_PAT: ${{ secrets.RELEASE_NOTES_PAT }}
         run: |
           pwd;ls;
           MESHERY_VERSION=${{ env.MESHERY_VERSION }}
           docker build \
             --no-cache \
             -t temp:latest \
-            --build-arg TOKEN="${{ secrets.RELEASE_NOTES_PAT }}" \
+            --secret id=token,env=RELEASE_NOTES_PAT \
             --build-arg GIT_COMMITSHA="${GITHUB_SHA::8}" \
             --build-arg GIT_VERSION="$MESHERY_VERSION" \
             --build-arg RELEASE_CHANNEL="stable" \

--- a/.github/workflows/build-and-release-meshery-extensions.yml
+++ b/.github/workflows/build-and-release-meshery-extensions.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           repository: layer5labs/meshery-extensions
           path: meshery-extensions
+          token: ${{ secrets.RELEASE_NOTES_PAT }}
       - name: Disable Source Map Warnings
         run: |
           echo 'DISABLE_SOURCEMAP_WARNINGS=true' >> $GITHUB_ENV
@@ -76,7 +77,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: meshery/meshery
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.RELEASE_NOTES_PAT }}
           path: meshery
           ref: ${{ env.MESHERY_VERSION }}
           sparse-checkout: |
@@ -114,7 +115,7 @@ jobs:
           docker build \
             --no-cache \
             -t temp:latest \
-            --build-arg TOKEN="${{ secrets.GH_ACCESS_TOKEN }}" \
+            --build-arg TOKEN="${{ secrets.RELEASE_NOTES_PAT }}" \
             --build-arg GIT_COMMITSHA="${GITHUB_SHA::8}" \
             --build-arg GIT_VERSION="$MESHERY_VERSION" \
             --build-arg RELEASE_CHANNEL="stable" \
@@ -128,7 +129,7 @@ jobs:
           extension_version=$(echo "${{ env.VERSION }}")
       - name: Get Meshery Extensions Release draft
         env:
-          ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.RELEASE_NOTES_PAT }}
         run: |
           curl -sL -H "Authorization: token $ACCESS_TOKEN" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/layer5labs/meshery-extensions/releases | jq -r '(map(select(.draft)) | first | .body) // ""' > releases.md
       - name: Release Draft Notes
@@ -148,7 +149,7 @@ jobs:
         with:
           owner: layer5labs
           repo: meshery-extensions-packages
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.RELEASE_NOTES_PAT }}
           tag: ${{ env.VERSION }}
           name: Meshery Extensions ${{ env.VERSION }}
           allowUpdates: true
@@ -164,7 +165,7 @@ jobs:
         with:
           owner: layer5labs
           repo: meshery-extensions
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.RELEASE_NOTES_PAT }}
           tag: ${{ env.VERSION }}
           name: Meshery Extensions ${{ env.VERSION }}
           allowUpdates: true
@@ -203,4 +204,4 @@ jobs:
         with:
           name: "Build and Rollout Kanvas"
           repo: layer5labs/meshery-extensions-packages
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ secrets.RELEASE_NOTES_PAT }}


### PR DESCRIPTION
## Summary
Second attempt at fixing the failing "Build and Publish Meshery Extensions" workflow. After #198 removed the `token:` override on the initial checkout, the step failed with:

```
Retrieving the default branch name
Not Found - https://docs.github.com/rest/repos/repos#get-a-repository
```

`layer5labs/meshery-extensions` is a **private** repository (I'd assumed public earlier — that was wrong). Two conclusions:
1. The default `GITHUB_TOKEN` from kanvas-site has no access to it → `Not Found`.
2. The previous `Bad credentials` we saw with `GH_ACCESS_TOKEN` means that secret is **stale / revoked / malformed** — not just insufficiently scoped.

## Fix
Switch every PAT reference in this workflow from `GH_ACCESS_TOKEN` to `RELEASE_NOTES_PAT`. That secret is already used by `release-notes.yml`, `release-drafter.yml`, and the goreleaser step in `build-and-release-ctl.yml` / `build-and-release-stable.yml` for cross-org GitHub operations, so it's known to be live and to have the access pattern we need.

Scoped use in this workflow:
- `actions/checkout` of `layer5labs/meshery-extensions` (private)
- `actions/checkout` of `meshery/meshery` (for `go.mod` sync)
- `docker build --build-arg TOKEN=` (private Go module fetch inside the image)
- `curl` for the release-draft body from `layer5labs/meshery-extensions`
- `ncipollo/release-action` publishes to `layer5labs/meshery-extensions-packages` and `layer5labs/meshery-extensions`
- `trigger-remote-provider-action` rollout

## Follow-up
`GH_ACCESS_TOKEN` is still referenced by ~10 other workflows in this repo. Those may be quietly broken too. Suggest rotating it at the org level separately.

## Test plan
- [ ] Re-run "Build and Publish Meshery Extensions" via workflow_dispatch on master after merge.
- [ ] Verify the `Checkout layer5labs/meshery-extensions` step succeeds.
- [ ] Verify `make graphql-sync`, the docker build, and both release publishes all succeed against `layer5labs/*`.