### PR TITLE
fix(ci): pin meshery-extensions checkout to master to skip REST API call

### DIFF
--- a/.github/workflows/build-and-release-meshery-extensions.yml
+++ b/.github/workflows/build-and-release-meshery-extensions.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: layer5labs/meshery-extensions
+          ref: master
           path: meshery-extensions
           token: ${{ secrets.RELEASE_NOTES_PAT }}
           persist-credentials: false


### PR DESCRIPTION
## Summary
Third attempt. Run [24525677154](https://github.com/meshery-extensions/kanvas-site/actions/runs/24525677154) failed identically to the first — `Bad credentials` from the GitHub REST API while `actions/checkout@v6` was resolving the default branch, even with `RELEASE_NOTES_PAT`.

The \"Retrieving the default branch name\" step is only reached when the caller doesn't supply `ref:`. Adding `ref: master` lets `actions/checkout` skip the REST lookup entirely and go straight to `git fetch`, which uses the token for HTTPS basic auth instead of the REST API.

## Why this might work
PATs can fail REST API auth while still working for git HTTPS. The most common cause is SAML/SSO: a classic PAT that hasn't been SSO-authorized for the `layer5labs` org will be rejected by `api.github.com` but still accepted for `git clone` over HTTPS. That pattern fits the symptom here.

## If this still fails
If `git fetch` also comes back with 401, the PAT is genuinely unusable and the fix is secret rotation at the org level — no workflow-code change can work around it. In that case the follow-up is:
- Create a fresh classic PAT (with `repo`, `workflow`) under an account that's a member of `layer5labs`, `meshery`, and `meshery-extensions`.
- SSO-authorize it for `layer5labs` and `meshery`.
- Update `GH_ACCESS_TOKEN` (and/or `RELEASE_NOTES_PAT`) in the `meshery-extensions` org secrets.

## Test plan
- [ ] Re-run \"Build and Publish Meshery Extensions\" via workflow_dispatch on master after merge.
- [ ] Watch the Checkout step — expect it to skip default-branch lookup and go straight to git fetch.
- [ ] If this passes, the rest of the workflow will likely run. If it fails on `meshery/meshery` checkout or on the release-action steps with 401, it's the PAT itself — see above.