### PR TITLE
Add theme toggle with persistence

### DIFF
--- a/assets/scss/_footer.scss
+++ b/assets/scss/_footer.scss
@@ -1,6 +1,6 @@
 .footer {
   position: relative;
-  background-color: #0a0a0a;
+  background-color: var(--surface-bg);
   color: $white;
   font-family: $font-qanelas;
   border-top: 1px solid rgba($primary, 0.12);

--- a/assets/scss/_header.scss
+++ b/assets/scss/_header.scss
@@ -2,7 +2,7 @@
   position: fixed;
   top: 24px;
   z-index: 1000;
-  background: $dark;
+  background: var(--header-bg);
   padding: 0.75rem 2rem;
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
@@ -22,10 +22,10 @@
   border: 1px solid transparent;
 
   &.scrolled {
-    background: rgba(10, 15, 20, 0.6);
+    background: var(--header-scrolled-bg);
     backdrop-filter: blur(24px) saturate(180%);
     -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-color: rgba(255, 255, 255, 0.06);
+    border-color: var(--header-border);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3),
                 inset 0 1px 0 rgba(255, 255, 255, 0.04);
   }
@@ -92,3 +92,23 @@
   }
 }
 
+
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--header-border);
+  background: var(--theme-toggle-bg);
+  color: var(--theme-toggle-text);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.35s ease, color 0.35s ease, border-color 0.35s ease, transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-1px);
+    border-color: rgba($primary, 0.45);
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -63,13 +63,13 @@ body {
 
 :root[data-theme="light"] {
   --page-bg: #f7fbfa;
-  --text-primary: #14221f;
+  --text-primary: #000000;
   --surface-bg: #ffffff;
   --header-bg: rgba(255, 255, 255, 0.94);
   --header-scrolled-bg: rgba(255, 255, 255, 0.78);
   --header-border: rgba(0, 0, 0, 0.08);
   --theme-toggle-bg: rgba(0, 0, 0, 0.06);
-  --theme-toggle-text: #14221f;
+  --theme-toggle-text: #000000;
 }
 
 html, body {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -50,3 +50,37 @@ body {
     box-shadow: 0 0 15px rgba($primary, 0.3);
   }
 }
+:root {
+  --page-bg: #121212;
+  --text-primary: #ffffff;
+  --surface-bg: #0a0a0a;
+  --header-bg: #121212;
+  --header-scrolled-bg: rgba(10, 15, 20, 0.6);
+  --header-border: rgba(255, 255, 255, 0.06);
+  --theme-toggle-bg: rgba(255, 255, 255, 0.06);
+  --theme-toggle-text: #ffffff;
+}
+
+:root[data-theme="light"] {
+  --page-bg: #f7fbfa;
+  --text-primary: #14221f;
+  --surface-bg: #ffffff;
+  --header-bg: rgba(255, 255, 255, 0.94);
+  --header-scrolled-bg: rgba(255, 255, 255, 0.78);
+  --header-border: rgba(0, 0, 0, 0.08);
+  --theme-toggle-bg: rgba(0, 0, 0, 0.06);
+  --theme-toggle-text: #14221f;
+}
+
+html, body {
+  transition: background-color 0.35s ease, color 0.35s ease;
+}
+
+body {
+  background-color: var(--page-bg);
+  color: var(--text-primary);
+}
+
+main {
+  background-color: var(--page-bg);
+}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,16 @@
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="msapplication-config" content="/favicons/browserconfig.xml">
   <meta name="theme-color" content="#ffffff">
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
+    <script>
+    (function () {
+      const storageKey = 'kanvas-theme';
+      const stored = localStorage.getItem(storageKey);
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = stored || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
   
   <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
   <meta property="og:title" content="{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}" />

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,6 +6,11 @@
       </a>
     </div>
 
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to light theme" aria-pressed="false">
+      <i class="fa-solid fa-moon" aria-hidden="true"></i>
+      <span class="theme-toggle-label">Dark</span>
+    </button>
+
     <!-- <nav class="main-nav">
       <ul>
         <li><a href="/features">Features</a></li>

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -591,6 +591,40 @@ const initScrollAnimations = () => {
     });
 };
 
+
+const initThemeToggle = () => {
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+
+    const icon = toggle.querySelector('i');
+    const label = toggle.querySelector('.theme-toggle-label');
+    const storageKey = 'kanvas-theme';
+
+    const applyTheme = (theme) => {
+        root.setAttribute('data-theme', theme);
+        const isDark = theme === 'dark';
+        toggle.setAttribute('aria-pressed', String(!isDark));
+        toggle.setAttribute('aria-label', isDark ? 'Switch to light theme' : 'Switch to dark theme');
+        if (icon) {
+            icon.classList.toggle('fa-moon', isDark);
+            icon.classList.toggle('fa-sun', !isDark);
+        }
+        if (label) label.textContent = isDark ? 'Dark' : 'Light';
+    };
+
+    const savedTheme = localStorage.getItem(storageKey);
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+        applyTheme(savedTheme);
+    }
+
+    toggle.addEventListener('click', () => {
+        const nextTheme = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(storageKey, nextTheme);
+        applyTheme(nextTheme);
+    });
+};
+
 const initVideoHandler = () => {
     const wrapper = document.getElementById('video-wrapper');
     const btn = document.getElementById('play-button-trigger');
@@ -611,6 +645,7 @@ const initVideoHandler = () => {
 document.addEventListener("DOMContentLoaded", () => {
     initMarquee();
     initVideoHandler();
+    initThemeToggle();
 
     const header = document.querySelector(".site-header");
     if (header) {


### PR DESCRIPTION
**Summary**

- Added a header theme toggle button (#theme-toggle) with accessible attributes and icon/label UI so users can switch between dark and light themes from the navbar. 
- Added an early inline script in <head> that reads localStorage (kanvas-theme) and falls back to prefers-color-scheme, then sets data-theme on <html> before page render to avoid theme flash. 
- Implemented global theme tokens using CSS custom properties for dark/light modes, plus smooth transitions on background/text for a consistent cross-page theme change effect. 
- Updated header styling to consume theme variables (--header-bg, --header-scrolled-bg, --header-border) and added styling for the new toggle control, including hover/transition behavior. 
- Updated footer surface background to use a theme variable so it visually stays in sync with the selected theme. 
- Added theme-toggle logic in main.js to:

1. initialize UI state from persisted theme,
2. update aria-label/aria-pressed + icon/label,
3. persist user choice in localStorage across sessions,
4. and bind toggle behavior on click. 

**Testing**

- ⚠️ make build (failed due to environment limitation: hugo not installed in container: make: hugo: No such file or directory)

Signed-off-by: raymondoyondi <raymondoyondi@gmail.com>

Closes #174 