### PR TITLE
[kanvas-site] Fix floating Kanvas logo blur consistency

### DIFF
--- a/assets/scss/_demo.scss
+++ b/assets/scss/_demo.scss
@@ -195,6 +195,8 @@
   .demo-card {
     padding: 40px;
     text-align: left;
+    backdrop-filter: blur(16px) saturate(160%);
+    -webkit-backdrop-filter: blur(16px) saturate(160%);
 
     .card-badges {
       display: flex;

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -258,6 +258,24 @@ const initScrollPieces = () => {
             }, '<');
         }
     });
+    const glassEls = Array.from(document.querySelectorAll('.glass, .glass--dark'));
+    if (glassEls.length) {
+        const updateBlurOnOverlap = () => {
+            anchors.forEach((anchor) => {
+                const stage = anchor.querySelector('.scroll-piece-stage');
+                if (!stage) return;
+                const sr = stage.getBoundingClientRect();
+                const overlaps = glassEls.some(gl => {
+                    const gr = gl.getBoundingClientRect();
+                    return sr.left < gr.right && sr.right > gr.left &&
+                        sr.top < gr.bottom && sr.bottom > gr.top;
+                });
+                stage.style.filter = overlaps ? 'blur(2px)' : '';
+            });
+        };
+        gsap.ticker.add(updateBlurOnOverlap);
+    }
+
 
     // ── Step 1: Reveal — pieces rise from background as browser section approaches ──
     if (browserSection) {
@@ -287,12 +305,12 @@ const initScrollPieces = () => {
             '.customers-section', '.hero-section', '.demo-section',
             '.capabilities-section', '.community-section', '.browser'
         ];
-        
+
         const orbitTargets = [
             { x: 35, y: 30 }, { x: 65, y: 30 }, { x: 70, y: 52 },
             { x: 60, y: 70 }, { x: 30, y: 52 }, { x: 48, y: 22 }
         ];
-        
+
         const startPositions = [];
         introSchedule.forEach((intro) => {
             const { pieceIdx, section } = intro;
@@ -319,19 +337,19 @@ const initScrollPieces = () => {
             scrub: true,
             onRefresh: () => {
                 if (!logoEl) return;
-                
+
                 // Temporarily disable the float animation to get the true untransformed center
                 const oldAnim = reunitedFloat.style.animation;
                 reunitedFloat.style.animation = 'none';
-                
+
                 const floatRect = reunitedFloat.getBoundingClientRect();
                 const scrollY = window.scrollY || document.documentElement.scrollTop;
                 const scrollX = window.scrollX || document.documentElement.scrollLeft;
-                
+
                 docLogoCenterX = floatRect.left + scrollX + floatRect.width / 2;
                 docLogoCenterY = floatRect.top + scrollY + floatRect.height / 2 - 24;
                 cachedDynamicScale = floatRect.width / 50 || 5.6;
-                
+
                 // Restore the float animation
                 reunitedFloat.style.animation = oldAnim;
             },
@@ -374,7 +392,7 @@ const initScrollPieces = () => {
                         y: currentY + 'px',
                         scale: cachedDynamicScale,
                         opacity: anchorOpacity,
-                        zIndex: progress > 0.8 ? -1 : 100
+                        zIndex: progress > 0.8 ? -1 : 10
                     });
 
                     gsap.set(body, { rotateY: 0, rotateX: 0 });


### PR DESCRIPTION
**Notes for Reviewers**

- This PR fixes #223 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

- Added backdrop blur support to .demo-card to maintain consistent blur styling for floating Kanvas logo elements across sections.
- This improves visual consistency between demo cards and other glassmorphism-based components.

Before : 

<img width="1918" height="907" alt="image" src="https://github.com/user-attachments/assets/bc80f6ce-e255-4fa4-80d8-071e198fd19f" />

After


https://github.com/user-attachments/assets/a5631551-b7e3-4d40-ac10-6d5cf8a08978

