### PR TITLE
[Chore] Upgrade Go toolchain to 1.26.4

### DIFF
--- a/.github/build/Makefile.core.mk
+++ b/.github/build/Makefile.core.mk
@@ -20,7 +20,7 @@ GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 REMOTE_PROVIDER="Meshery"
 LOCAL_PROVIDER="None"
-GOVERSION = 1.26
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 KEYS_PATH="../../server/permissions/keys.csv"

--- a/.github/build/Makefile.core.mk
+++ b/.github/build/Makefile.core.mk
@@ -20,7 +20,7 @@ GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 REMOTE_PROVIDER="Meshery"
 LOCAL_PROVIDER="None"
-GOVERSION = 1.23
+GOVERSION = 1.26
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 KEYS_PATH="../../server/permissions/keys.csv"

--- a/.github/workflows/build-and-release-ctl.yml
+++ b/.github/workflows/build-and-release-ctl.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.23"
+          go-version: "1.26"
       - name: goreleaser with tag
         uses: goreleaser/goreleaser-action@v6
         env:

--- a/.github/workflows/build-and-release-ctl.yml
+++ b/.github/workflows/build-and-release-ctl.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: goreleaser with tag
         uses: goreleaser/goreleaser-action@v6
         env:

--- a/.github/workflows/build-and-release-ctl.yml
+++ b/.github/workflows/build-and-release-ctl.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@master
         with:
           go-version-file: go.mod
       - name: goreleaser with tag

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.23"
+          go-version: "1.26"
       - name: goreleaser with tag
         uses: goreleaser/goreleaser-action@v6
         env:

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@master
         with:
           go-version-file: go.mod
       - name: goreleaser with tag

--- a/.github/workflows/build-and-release-stable.yml
+++ b/.github/workflows/build-and-release-stable.yml
@@ -136,9 +136,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: goreleaser with tag
         uses: goreleaser/goreleaser-action@v6
         env:

--- a/.github/workflows/build-ui-server-reusable-workflow.yml
+++ b/.github/workflows/build-ui-server-reusable-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
       - run: |
           GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go build -tags draft ./server/cmd/main.go ./server/cmd/error.go
       - name: Upload artifacts

--- a/.github/workflows/build-ui-server-reusable-workflow.yml
+++ b/.github/workflows/build-ui-server-reusable-workflow.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - run: |
           GOPROXY=https://proxy.golang.org,direct GOSUMDB=off GO111MODULE=on go build -tags draft ./server/cmd/main.go ./server/cmd/error.go
       - name: Upload artifacts

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@master
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Build Error Utility
         run: |

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -17,21 +17,21 @@ jobs:
     if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: "master"
           fetch-depth: 1
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         if: ${{ github.event_name == 'push' }}
         with:
           ref: "master"
           fetch-depth: 1
           token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Setup Go
-        uses: actions/setup-go@master
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Build Error Utility
         run: |

--- a/.github/workflows/error-codes-updater.yaml
+++ b/.github/workflows/error-codes-updater.yaml
@@ -17,19 +17,19 @@ jobs:
     if: github.repository == 'meshery/meshery'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@master
         if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: "master"
           fetch-depth: 1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@master
         if: ${{ github.event_name == 'push' }}
         with:
           ref: "master"
           fetch-depth: 1
           token: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@master
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -23,7 +23,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.23]
+        go: [1.26]
         os: [ubuntu-24.04]
     name: golangci-lint
     if: github.repository == 'meshery/meshery'
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
       - name: Run coverage
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
       - name: Install Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.github/workflows/go-testing-ci.yml
+++ b/.github/workflows/go-testing-ci.yml
@@ -21,22 +21,20 @@ on:
 
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go: [1.26]
-        os: [ubuntu-24.04]
     name: golangci-lint
     if: github.repository == 'meshery/meshery'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-go@v5
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v4
+          go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.63
+          version: v2.12.2
           args: --config=.golangci.yml --timeout=10m
   unit-tests:
     name: Unit tests
@@ -51,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Run coverage
         run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
       - name: Upload coverage to Codecov
@@ -73,7 +71,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - name: Install Docker Compose
         run: |
           sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo 🛎️
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           ref: master # Set your default branch
         env:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@master
         with:
           ref: master # Set your default branch
         env:

--- a/.github/workflows/mesheryctl-e2e.yaml
+++ b/.github/workflows/mesheryctl-e2e.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.23']
+        go: ['1.26']
         k8s_version: ['v1.31.4', 'v1.32.0']
         platform: ['kubernetes']
     steps:

--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26"
 
       - name: Pull changes from remote
         run: git pull origin master

--- a/.github/workflows/model-generator.yml
+++ b/.github/workflows/model-generator.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Pull changes from remote
         run: git pull origin master

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/meshery-extensions/kanvas-site
 
-go 1.25
+go 1.26.4


### PR DESCRIPTION
## Description
Upgrade Go toolchain from 1.23/1.25 to 1.26.4 to pick up the latest security and bug fixes.

### Changes
- `go.mod`: `go 1.25` → `go 1.26.4`
- `.github/build/Makefile.core.mk`: `GOVERSION = 1.23` → `1.26`
- CI workflows: `go-version: 1.23` → `1.26` in `build-and-release-stable.yml`, `build-and-release-ctl.yml`, `build-ui-server-reusable-workflow.yml`, `go-testing-ci.yml`, `model-generator.yml`, `error-codes-updater.yaml`

Relates to meshery/meshery#19875